### PR TITLE
Configurable NUMA allocation fallback order override

### DIFF
--- a/tpp/README.md
+++ b/tpp/README.md
@@ -1,4 +1,4 @@
-# HeMem + colloid
+# TPP + colloid
 
 This directory contains implementation of [colloid](https://github.com/webglider/colloid/) on top of TPP.
 
@@ -46,6 +46,8 @@ vi .config
 CONFIG_LOCALVERSION="-colloid"
 ...
 ```
+
+If you are using a server with more than two sockets, then you may need to additionally update .config to override the default NUMA allocation fallback order. Please see [here](fallback.md) for instructions (if using a single or dual-socket server, then this is not necessary).
 
 Compile and install (update -j with number of cores you want to use):
 

--- a/tpp/fallback.md
+++ b/tpp/fallback.md
@@ -1,0 +1,7 @@
+### Overriding NUMA fallback allocation order
+
+When the memory capacity of a NUMA node is exhausted, Linux tries to allocate memory from a different NUMA node based on a fallback order determined at boot time. If using a server with more than two sockets for tiered memory emulation, then the fallback order may need to be udpated. For example, say you have a 4-socket server with NUMA nodes 0,1,2,3, and you want to use NUMA node 3 as the default tier and NUMA node 2 as the alternate tier. Say the Linux default fallback order for NUMA node 3 is 0,1,2. We need to update this fallback order so that NUMA node 2 comes first (e.g., 2,0,1) to ensure that memory is allocated in the alternate tier NUMA node once default tier NUAM node capacity is exhausted.
+
+TPP+Colloid kernel provides a configuration option to automatically override the allocation fallback order to handle the above. For this, before building the kernel set `ONFIG_COLLOID_OVERRIDE_FALLBACK=y` in .config, and set `CONFIG_COLLOID_DEFAULT_TIER_NUMA` to the NUMA node number of the default tier, and `CONFIG_COLLOID_ALTERNATE_TIER_NUMA` to the NUMA node number of the alternate tier.
+
+After building and booting the kernel, you can verify that the fallback order is as desired using: `dmesg | grep -i fallback`.

--- a/tpp/linux-6.3/mm/Kconfig
+++ b/tpp/linux-6.3/mm/Kconfig
@@ -1204,4 +1204,31 @@ config LRU_GEN_STATS
 
 source "mm/damon/Kconfig"
 
+menu "Colloid NUMA Configuration"
+
+config COLLOID_OVERRIDE_FALLBACK
+    bool "Enable override fallback for Colloid"
+    default n
+    help
+      Enable or disable override for fallback NUMA order.
+      Say 'y' to enable and 'n' to disable.
+
+config COLLOID_DEFAULT_TIER_NUMA
+    int "Default NUMA tier for Colloid"
+    default 0
+    help
+      Specify the default NUMA tier for Colloid.
+	  Only used if COLLOID_OVERRIDE_FALLBACK is enabled.
+      Must be an integer.
+
+config COLLOID_ALTERNATE_TIER_NUMA
+    int "Alternate NUMA tier for Colloid"
+    default 1
+    help
+      Specify the alternate NUMA tier for Colloid.
+	  Only used if COLLOID_OVERRIDE_FALLBACK is enabled.
+      Must be an integer.
+
+endmenu
+
 endmenu


### PR DESCRIPTION
- Make NUMA node allocation fallback order override configurable in Kconfig since this is may be needed only on servers with more than two sockets