### PR TITLE
Add Intel Haswell support and sysfs interface

### DIFF
--- a/tpp/colloid-mon/Makefile
+++ b/tpp/colloid-mon/Makefile
@@ -37,6 +37,18 @@ else ifeq ($(BACKEND), clx-native)
         $(error Backend $(BACKEND) does not support tier $(ALTERNATE_TIER).)
     endif
     endif
+else ifeq ($(BACKEND), hsw-native)
+	colloid-mon-objs += backend/hsw-native.o
+	ifneq ($(DEFAULT_TIER), local-dram)
+    ifneq ($(DEFAULT_TIER), remote-dram)
+        $(error Backend $(BACKEND) does not support tier $(DEFAULT_TIER).)
+    endif
+    endif
+	ifneq ($(ALTERNATE_TIER), local-dram)
+    ifneq ($(ALTERNATE_TIER), remote-dram)
+        $(error Backend $(BACKEND) does not support tier $(ALTERNATE_TIER).)
+    endif
+    endif
 else
 	$(error Invalid backend: $(BACKEND).)
 endif

--- a/tpp/colloid-mon/backend/hsw-native.c
+++ b/tpp/colloid-mon/backend/hsw-native.c
@@ -1,0 +1,103 @@
+#include "backend_iface.h"
+#include <linux/kernel.h>
+#include <asm/msr.h>
+
+// CHA counters are MSR-based.  
+//   The starting MSR address is 0x0E00 + 0x10*CHA
+//   	Offset 0 is Unit Control -- mostly un-needed
+//   	Offsets 1-4 are the Counter PerfEvtSel registers
+//   	Offset 5 is Filter0	-- selects state for LLC lookup event (and TID, if enabled by bit 19 of PerfEvtSel)
+//   	Offset 6 is Filter1 -- lots of filter bits, including opcode -- default if unused should be 0x03b, or 0x------33 if using opcode matching
+//   	Offset 7 is Unit Status
+//   	Offsets 8,9,A,B are the Counter count registers
+#define CHA_MSR_PMON_BASE 0x0E00L
+#define CHA_MSR_PMON_CTL_BASE 0x0E01L
+#define CHA_MSR_PMON_FILTER0_BASE 0x0E05L
+#define CHA_MSR_PMON_FILTER1_BASE 0x0E06L
+#define CHA_MSR_PMON_STATUS_BASE 0x0E07L
+#define CHA_MSR_PMON_CTR_BASE 0x0E08L
+#define CHA_OFFSET 0x10
+
+#define FILTER1_LOCAL_VAL ((0x182 << 20) + 1)
+#define FILTER1_REMOTE_VAL ((0x182 << 20) + 2)
+#define CTL_OCCUPANCY 0x404336
+#define CTL_INSERTS 0x404335
+
+#define NUM_CHA_BOXES 10
+#define NUM_CHA_COUNTERS 4
+
+static int core_mon;
+
+int backend_init(struct backend_config* config) {
+    int cha, ret;
+    u32 msr_num;
+    u64 msr_val;
+
+    if(!config) {
+        printk(KERN_ERR "hsw-native: invalid backend_config passed\n");
+        return -1;
+    }
+
+    core_mon = config->core;
+    pr_err("core mon %d\n", core_mon);
+
+    for(cha = 0; cha < NUM_CHA_BOXES; cha++) {
+        msr_num = CHA_MSR_PMON_FILTER0_BASE + (CHA_OFFSET * cha); // Filter0
+        msr_val = 0x00000000; // default; no filtering
+        ret = wrmsr_on_cpu(core_mon, msr_num, msr_val & 0xFFFFFFFF, msr_val >> 32);
+        if(ret != 0) {
+            printk(KERN_ERR "hsw-native: wrmsr FILTER0 failed\n");
+            return -1;
+        }
+
+        msr_num = CHA_MSR_PMON_FILTER1_BASE + (CHA_OFFSET * cha); // Filter1
+        msr_val = (cha%2==0) ? FILTER1_LOCAL_VAL : FILTER1_REMOTE_VAL;
+        ret = wrmsr_on_cpu(core_mon, msr_num, msr_val & 0xFFFFFFFF, msr_val >> 32);
+        if (ret != 0) {
+            printk(KERN_ERR "hsw-native: wrmsr FILTER1 failed\n");
+            return -1;
+        }
+
+        msr_num = CHA_MSR_PMON_CTL_BASE + (CHA_OFFSET * cha) + 0; //counter 0
+        msr_val = CTL_OCCUPANCY;
+        ret = wrmsr_on_cpu(core_mon, msr_num, msr_val & 0xFFFFFFFF, msr_val >> 32);
+        if (ret != 0) {
+            printk(KERN_ERR "hsw-native: wrmsr COUNTER 0 failed\n");
+            return -1;
+        }
+
+        msr_num = CHA_MSR_PMON_CTL_BASE + (CHA_OFFSET * cha) + 1; // counter 1
+        msr_val = CTL_INSERTS;
+        ret = wrmsr_on_cpu(core_mon, msr_num, msr_val & 0xFFFFFFFF, msr_val >> 32);
+        if (ret != 0) {
+            printk(KERN_ERR "hsw-native: wrmsr COUNTER 1 failed\n");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int backend_destroy() {
+    return 0;
+}
+
+u64 backend_read_occupancy(int tier) {
+    int cha, ctr;
+    u32 msr_num, msr_high, msr_low;
+    cha = tier; // Default tier on CHA slice 0, Alternate tier on CHA slice 1
+    ctr = 0; // Occupancy
+    msr_num = CHA_MSR_PMON_CTR_BASE + (CHA_OFFSET * cha) + ctr;    
+    rdmsr_on_cpu(core_mon, msr_num, &msr_low, &msr_high);
+    return ((((u64)msr_high) << 32) | ((u64)msr_low));
+}
+
+u64 backend_read_inserts(int tier) {
+    int cha, ctr;
+    u32 msr_num, msr_high, msr_low;
+    cha = tier; // Default tier on CHA slice 0, Alternate tier on CHA slice 1
+    ctr = 1; // Inserts
+    msr_num = CHA_MSR_PMON_CTR_BASE + (CHA_OFFSET * cha) + ctr;    
+    rdmsr_on_cpu(core_mon, msr_num, &msr_low, &msr_high);
+    return ((((u64)msr_high) << 32) | ((u64)msr_low));
+}

--- a/tpp/colloid-mon/config.mk
+++ b/tpp/colloid-mon/config.mk
@@ -5,6 +5,7 @@
 # Currently supported values
 # 	icx-native: Intel Icelake (native)
 # 	clx-native: Intel Cascadelake (native)
+# 	hsw-native: Intel Haswell (native)
 BACKEND ?= icx-native
 
 # Default/alternate tier types

--- a/tpp/colloid-mon/frontend.c
+++ b/tpp/colloid-mon/frontend.c
@@ -168,9 +168,30 @@ static void init_mon_state(void) {
     log_idx = 0;
 }
 
+static ssize_t colloid_latencies_show(struct kobject *kobj,
+        struct kobj_attribute *attr, char *buf)
+{
+    return sprintf(buf, "local %llu remote %llu\n",
+        smoothed_lat_local, smoothed_lat_remote);
+}
+static struct kobj_attribute colloid_latency_attr =
+__ATTR(latency, 0444, colloid_latencies_show, NULL);
+
+static struct attribute *colloid_attr[] = {
+    &colloid_latency_attr.attr,
+};
+
+static const struct attribute_group colloid_attr_group = {
+    .attrs = colloid_attr,
+};
+
+struct kobject *colloid_kobj = NULL;
+
 static int colloidmon_init(void)
 {
     int i;
+    int err;
+
     poll_cha_queue = alloc_workqueue("poll_cha_queue",  WQ_HIGHPRI | WQ_CPU_INTENSIVE, 0);
     if (!poll_cha_queue) {
         printk(KERN_ERR "Failed to create CHA workqueue\n");
@@ -195,6 +216,19 @@ static int colloidmon_init(void)
 
     WRITE_ONCE(colloid_nid_of_interest, LOCAL_NUMA);
 
+    colloid_kobj = kobject_create_and_add("colloid", kernel_kobj);
+    if (unlikely(!colloid_kobj)) {
+        printk(KERN_ERR "Failed to create colloid kobj\n");
+        return -ENOMEM;
+    }
+
+    err = sysfs_create_group(colloid_kobj, &colloid_attr_group);
+    if (err) {
+        printk(KERN_ERR "Failed to register colloid group\n");
+        kobject_put(colloid_kobj);
+        return err;
+    }
+
     for(i = 0; i < 5; i++) {
         msleep(1000);
         printk("%llu %llu\n", READ_ONCE(smoothed_occ_local), READ_ONCE(smoothed_occ_remote));
@@ -209,6 +243,11 @@ static void colloidmon_exit(void)
     msleep(5000);
     flush_workqueue(poll_cha_queue);
     destroy_workqueue(poll_cha_queue);
+
+    if (colloid_kobj) {
+        sysfs_remove_group(colloid_kobj, &colloid_attr_group);
+        kobject_put(colloid_kobj);
+    }
 
     // dump_log();
 


### PR DESCRIPTION
This PR has two commits.

The first adds a backend for reading the local and remote NUMA latency values on the Haswell arch.
The second adds a sysfs interface that prints the current local and remote latency values. I've found this to be useful for verifying that Colloid is working as expected, and for determining the minimum latency values when running on new hardware.